### PR TITLE
Use shell on windows to execute command

### DIFF
--- a/conda_execute/execute.py
+++ b/conda_execute/execute.py
@@ -111,10 +111,8 @@ def execute_within_env(env_prefix, cmd):
         paths = [os.path.join(env_prefix),
                  os.path.join(env_prefix, 'Scripts'),
                  os.path.join(env_prefix, 'bin')]
-        use_shell = True
     else:
         paths = [os.path.join(env_prefix, 'bin')]
-        use_shell = False
 
     environ = os.environ.copy()
     # Note os.pathsep != os.path.sep. It caught me out too ;)
@@ -123,8 +121,9 @@ def execute_within_env(env_prefix, cmd):
     # The default is a non-zero return code. Successful processes will set this themselves.
     code = 42
     try:
+        os.chdir(env_prefix)  # enable cmd relative to prefix
         log.debug('Executing command: {}'.format(cmd))
-        code = subprocess.check_call(cmd, env=environ, shell=use_shell)
+        code = subprocess.check_call(cmd, env=environ)
     except subprocess.CalledProcessError as exception:
         code = exception.returncode
         log.warn('{}: {}'.format(type(exception).__name__, exception))

--- a/conda_execute/execute.py
+++ b/conda_execute/execute.py
@@ -123,6 +123,7 @@ def execute_within_env(env_prefix, cmd):
     # The default is a non-zero return code. Successful processes will set this themselves.
     code = 42
     try:
+        log.debug('Executing command: {}'.format(cmd))
         code = subprocess.check_call(cmd, env=environ, shell=use_shell)
     except subprocess.CalledProcessError as exception:
         code = exception.returncode

--- a/conda_execute/execute.py
+++ b/conda_execute/execute.py
@@ -12,7 +12,7 @@ import time
 import shutil
 import stat
 import subprocess
- 
+
 import conda.api
 import conda.lock
 import conda.resolve
@@ -33,11 +33,11 @@ def extract_env_spec(handle):
         if in_spec is True:
             # FIXME: we are pretty fragile with whitespace at this point.
             if line.startswith('#  - '):
-                spec.append(line[5:].strip()) 
+                spec.append(line[5:].strip())
             elif not line.startswith('# '):
                 # We're done with the spec.
                 break
-                
+
         elif line.strip() == '# conda execute env:':
             in_spec = True
     return spec
@@ -73,7 +73,7 @@ def extract_spec(fh):
     if platform.system() != 'Windows':
         spec.setdefault('run_with', ['/bin/sh', '-c'])
 
-    return spec 
+    return spec
 
 
 def read_shebang(line):
@@ -155,7 +155,7 @@ def create_env(spec, force_recreation=False, extra_channels=()):
         r = conda.resolve.Resolve(index)
         full_list_of_packages = sorted(r.solve(spec))
 
-        # Put out a newline. Conda's solve doesn't do it for us. 
+        # Put out a newline. Conda's solve doesn't do it for us.
         log.info('\n')
 
         for tar_name in full_list_of_packages:
@@ -209,8 +209,8 @@ def main():
     parser.add_argument('--code', '-c', nargs='*', action=StdIn,
                         help='The code to execute.')
     parser.add_argument('remaining_args', help='Remaining arguments are passed through to the called script.',
-                        nargs=argparse.REMAINDER) 
-    args = parser.parse_args() 
+                        nargs=argparse.REMAINDER)
+    args = parser.parse_args()
 
     log_level = logging.WARN
     if args.verbose:

--- a/conda_execute/execute.py
+++ b/conda_execute/execute.py
@@ -111,8 +111,10 @@ def execute_within_env(env_prefix, cmd):
         paths = [os.path.join(env_prefix),
                  os.path.join(env_prefix, 'Scripts'),
                  os.path.join(env_prefix, 'bin')]
+        use_shell = True
     else:
         paths = [os.path.join(env_prefix, 'bin')]
+        use_shell = False
 
     environ = os.environ.copy()
     # Note os.pathsep != os.path.sep. It caught me out too ;)
@@ -121,7 +123,7 @@ def execute_within_env(env_prefix, cmd):
     # The default is a non-zero return code. Successful processes will set this themselves.
     code = 42
     try:
-        code = subprocess.check_call(cmd, env=environ)
+        code = subprocess.check_call(cmd, env=environ, shell=use_shell)
     except subprocess.CalledProcessError as exception:
         code = exception.returncode
         log.warn('{}: {}'.format(type(exception).__name__, exception))


### PR DESCRIPTION
Not sure if this would be the best approach to fix the issue of `PATH` not being used on Windows. See #5.