### PR TITLE
Windows conda execute PATH not being used

### DIFF
--- a/conda_execute/tmpenv.py
+++ b/conda_execute/tmpenv.py
@@ -182,7 +182,9 @@ def subcommand_create(args):
 
 
 def subcommand_clear(args):
-    return cleanup_tmp_envs(min_age=float(args.min_age))
+    if args.min_age is not None:
+        args.min_age = float(args.min_age)
+    return cleanup_tmp_envs(min_age=args.min_age)
 
 
 def cleanup_tmp_envs(min_age=None):

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -17,6 +17,10 @@ conda tmpenv create python --file spec.txt
 rm spec.txt
 
 
+conda tmpenv list
+conda tmpenv clear
+conda tmpenv clear --min-age=0
+
 
 # Conda execute
 #--------------


### PR DESCRIPTION
As per the discussion in #5 this adds a distutils.spawn.find_executable call on Windows. There is an awkwardness that one could use relative paths in the ```run_with``` metadata - I don't think that is necessarily a good thing to be doing on any platform.

Closes #5.