### PR TITLE
Changed the type being passed through to conda's solve to avoid formatting errors.

### DIFF
--- a/conda_execute/tmpenv.py
+++ b/conda_execute/tmpenv.py
@@ -69,7 +69,7 @@ def create_env(spec, force_recreation=False, extra_channels=()):
             index = conda.api.get_index(extra_channels)
             # Ditto re the quietness.
             r = conda.resolve.Resolve(index)
-            full_list_of_packages = sorted(r.solve(spec))
+            full_list_of_packages = sorted(r.solve(list(spec)))
 
             # Put out a newline. Conda's solve doesn't do it for us.
             log.info('\n')


### PR DESCRIPTION
Fixes bugs like:

```
Traceback (most recent call last):
  File "/home/travis/conda/bin/conda-execute", line 9, in <module>
    load_entry_point('conda-execute==0.4.0', 'console_scripts', 'conda-execute')()
  File "/home/travis/conda/lib/python2.7/site-packages/conda_execute/execute.py", line 177, in main
    exit(execute(path, force_env=args.force_env, arguments=args.remaining_args))
  File "/home/travis/conda/lib/python2.7/site-packages/conda_execute/execute.py", line 84, in execute
    env_prefix = create_env(env_spec, force_env, spec.get('channels', []))
  File "/home/travis/conda/lib/python2.7/site-packages/conda_execute/tmpenv.py", line 72, in create_env
    full_list_of_packages = sorted(r.solve(spec))
  File "/home/travis/conda/lib/python2.7/site-packages/conda/resolve.py", line 887, in solve
    dotlog.debug("Solving for %s" % specs)
TypeError: not all arguments converted during string formatting
```