### PR TITLE
ENH: Prototype remote script download/execute

### DIFF
--- a/conda_execute/execute.py
+++ b/conda_execute/execute.py
@@ -9,7 +9,6 @@ import tempfile
 import shutil
 import stat
 import subprocess
-import tempfile
 import requests
 
 import conda.api
@@ -196,12 +195,13 @@ def main():
     exit_actions = []
 
     try:
+        path = None
         if args.path:
             if is_url(args.path):
                 args.code = download(args.path)
             else:
                 path = os.path.abspath(args.path)
-        if args.code:
+        if path is None and args.code:
             with tempfile.NamedTemporaryFile(prefix='conda-execute_',
                                              delete=False, mode='w') as fh:
                 fh.writelines(args.code)

--- a/conda_execute/execute.py
+++ b/conda_execute/execute.py
@@ -155,7 +155,7 @@ def download(url):
     r = requests.get(url)
     return r.content.decode()
 
-_NAMED_TEMP_FILE_KWARGS = {}
+
 def main():
     parser = argparse.ArgumentParser(description='Execute a script in a temporary conda environment.')
     parser.add_argument('path', nargs='?',
@@ -195,13 +195,9 @@ def main():
     exit_actions = []
 
     try:
-        path = None
-        if args.path:
-            if is_url(args.path):
-                args.code = download(args.path)
-            else:
-                path = os.path.abspath(args.path)
-        if path is None and args.code:
+        if args.path is not None and is_url(args.path):
+            args.code = download(args.path)
+        if args.code:
             with tempfile.NamedTemporaryFile(prefix='conda-execute_',
                                              delete=False, mode='w') as fh:
                 fh.writelines(args.code)
@@ -211,6 +207,8 @@ def main():
                 exit_actions.append(lambda: os.remove(path))
                 # Make the file executable.
                 os.chmod(path, stat.S_IREAD | stat.S_IEXEC)
+        elif args.path:
+            path = os.path.abspath(args.path)
         else:
             raise ValueError('Either pass the filename to execute, or pipe with -c.')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ setuptools
 pyyaml
 conda
 psutil
+requests

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -56,7 +56,7 @@ conda execute $example_script wibble --arg1=123 foobar
 
 
 cat <<EOF > $tmp_script
-#!/usr/bin/env conda-execute 
+#!/usr/bin/env conda-execute
 """
 A script that uses numpy's random normal distribution to print 10 numbers.
 
@@ -78,4 +78,4 @@ chmod u+x $tmp_script
 $tmp_script
 
 
-
+conda execute https://raw.githubusercontent.com/pelson/conda-execute/master/example.sh


### PR DESCRIPTION
This adds a prototype implementation of detecting that the input to conda-execute
is actually a url and then downloading the contents of that url and executing it.

Addresses #18 