### PR TITLE
Prevent conda-execute from failing when a temp env exists with no execution.log file

### DIFF
--- a/conda_execute/tests/test_tmpenv.py
+++ b/conda_execute/tests/test_tmpenv.py
@@ -1,0 +1,34 @@
+import logging
+import os
+import unittest
+
+import conda_execute.execute
+import conda_execute.tmpenv
+
+from conda_execute.tests import tmp_script
+
+
+class Test_tmpenv(unittest.TestCase):
+    def test_conda_execute_removes_envs_with_no_exe_log(self):        
+        script = """
+        # conda execute
+        # env:
+        #  - python >=3
+        #  - numpy
+        # run_with: python
+        """
+        with tmp_script(script) as fname:
+            fh = open(fname, 'r')
+            spec = conda_execute.execute.extract_spec(fh)
+            env_spec = spec.get('env', [])
+            env_locn = conda_execute.tmpenv.create_env(env_spec)
+            # Remove the execution.log file in this environment to test that 
+            # cleanup_tmp_envs removes the environment when it's called
+            exe_log_loc = os.path.join(env_locn, 'conda-meta', 'execution.log')
+            if os.path.exists(exe_log_loc):
+                os.remove(exe_log_loc)
+            conda_execute.tmpenv.cleanup_tmp_envs()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/conda_execute/tmpenv.py
+++ b/conda_execute/tmpenv.py
@@ -104,6 +104,8 @@ def subcommand_list(args):
 
     """
     for env, env_stats in envs_and_running_pids():
+        if env_stats is None:
+            continue
         last_pid_dt = datetime.datetime.fromtimestamp(env_stats['latest_creation_time'])
         age = datetime.datetime.now() - last_pid_dt
         old = age > datetime.timedelta(conda_execute.config.min_age)


### PR DESCRIPTION
Closes issue https://github.com/pelson/conda-execute/issues/28