### PR TITLE
Creating tmpenv without spec

### DIFF
--- a/conda_execute/tmpenv.py
+++ b/conda_execute/tmpenv.py
@@ -215,7 +215,7 @@ def main():
                                        description='valid subcommands',
                                        help='additional help')
     common_arguments = argparse.ArgumentParser(add_help=False)
-    common_arguments.add_argument('--verbose', '-v', action='store_true')
+    common_arguments.add_argument('--verbose', '-v', action='store_true', help='show debug output')
 
     list_subcommand = subparsers.add_parser('list', parents=[common_arguments])
     list_subcommand.set_defaults(subcommand_func=subcommand_list)

--- a/conda_execute/tmpenv.py
+++ b/conda_execute/tmpenv.py
@@ -221,8 +221,10 @@ def main():
     list_subcommand.set_defaults(subcommand_func=subcommand_list)
 
     creation_args = argparse.ArgumentParser(add_help=False)
-    creation_args.add_argument('specs', nargs='*')
-    creation_args.add_argument('--file', default=[], action='append')
+    creation_args.add_argument('specs', nargs='*', help='Packages to install into the temporary environment')
+    creation_args.add_argument('--file', default=[], action='append',
+                               help=('Read package versions from the given file. Repeated file '
+                                     'specifications can be passed (e.g. --file=file1 --file=file2)'))
 
     create_subcommand = subparsers.add_parser('create', parents=[common_arguments, creation_args])
     create_subcommand.set_defaults(subcommand_func=subcommand_create)

--- a/conda_execute/tmpenv.py
+++ b/conda_execute/tmpenv.py
@@ -163,7 +163,7 @@ def envs_and_running_pids():
                     if alive:
                         alive_pids.append(pid)
                         env_stats = {'alive_PIDs': alive_pids, 'latest_creation_time': newest_pid_time}
-            yield env, env_stats 
+            yield env, env_stats
 
 
 def subcommand_name(args):
@@ -176,11 +176,11 @@ def subcommand_name(args):
 
 
 def subcommand_create(args):
-    log.info('Creating an environment with {}'.format(args.specs))
     specs = list(args.specs)
     for fname in args.file:
         with open(fname) as fh:
             specs.extend([line.strip() for line in fh])
+    log.info('Creating an environment with {}'.format(specs))
     r = create_env(specs, force_recreation=args.force)
     # Output the created environment name
     print(r)

--- a/conda_execute/tmpenv.py
+++ b/conda_execute/tmpenv.py
@@ -180,6 +180,10 @@ def subcommand_create(args):
     for fname in args.file:
         with open(fname) as fh:
             specs.extend([line.strip() for line in fh])
+    if not specs:
+        import sys
+        print("Error: no packages to install, must supply command line package specs or --file.", file=sys.stderr)
+        return 1
     log.info('Creating an environment with {}'.format(specs))
     r = create_env(specs, force_recreation=args.force)
     # Output the created environment name

--- a/conda_execute/tmpenv.py
+++ b/conda_execute/tmpenv.py
@@ -219,7 +219,8 @@ def main():
                                        description='valid subcommands',
                                        help='additional help')
 
-    list_subcommand = subparsers.add_parser('list', parents=[common_arguments])
+    list_subcommand = subparsers.add_parser('list', parents=[common_arguments],
+                                            help='List temporary environments.')
     list_subcommand.set_defaults(subcommand_func=subcommand_list)
 
     creation_args = argparse.ArgumentParser(add_help=False)
@@ -228,14 +229,17 @@ def main():
                                help=('Read package versions from the given file. Repeated file '
                                      'specifications can be passed (e.g. --file=file1 --file=file2)'))
 
-    create_subcommand = subparsers.add_parser('create', parents=[common_arguments, creation_args])
+    create_subcommand = subparsers.add_parser('create', parents=[common_arguments, creation_args],
+                                              help='Create a new environment from specifications.')
     create_subcommand.set_defaults(subcommand_func=subcommand_create)
     create_subcommand.add_argument('--force', help='Whether to force the re-creation of the environment, even if it already exists.', action='store_true')
 
-    name_subcommand = subparsers.add_parser('name', parents=[common_arguments, creation_args], help='Get the full prefix for a specified environment.')
+    name_subcommand = subparsers.add_parser('name', parents=[common_arguments, creation_args],
+                                            help='Get the full prefix for a specified environment.')
     name_subcommand.set_defaults(subcommand_func=subcommand_name)
 
-    clear_subcommand = subparsers.add_parser('clear', parents=[common_arguments])
+    clear_subcommand = subparsers.add_parser('clear', parents=[common_arguments],
+                                             help='Clean up unused temporary environments.')
     clear_subcommand.set_defaults(subcommand_func=subcommand_clear)
     clear_subcommand.add_argument('--min-age', help=('The minimum age for the last registered PID on an '
                                                      'environment, before the environment can be considered '

--- a/conda_execute/tmpenv.py
+++ b/conda_execute/tmpenv.py
@@ -250,7 +250,9 @@ def main():
     conda_execute.config.setup_logging(log_level)
 
     log.debug('Arguments passed: {}'.format(args))
-    exit(args.subcommand_func(args))
+    if hasattr(args, 'subcommand_func'):
+        exit(args.subcommand_func(args))
+    parser.error('No command specified')
 
 
 if __name__ == '__main__':

--- a/conda_execute/tmpenv.py
+++ b/conda_execute/tmpenv.py
@@ -210,12 +210,14 @@ def cleanup_tmp_envs(min_age=None):
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Manage temporary environments within conda.')
+    common_arguments = argparse.ArgumentParser(add_help=False)
+    common_arguments.add_argument('--verbose', '-v', action='store_true', help='show debug output')
+
+    parser = argparse.ArgumentParser(description='Manage temporary environments within conda.',
+                                     parents=[common_arguments])
     subparsers = parser.add_subparsers(title='subcommands',
                                        description='valid subcommands',
                                        help='additional help')
-    common_arguments = argparse.ArgumentParser(add_help=False)
-    common_arguments.add_argument('--verbose', '-v', action='store_true', help='show debug output')
 
     list_subcommand = subparsers.add_parser('list', parents=[common_arguments])
     list_subcommand.set_defaults(subcommand_func=subcommand_list)


### PR DESCRIPTION
Presumably creating a tmpenv without spec is not supposed to be allowed. It fails if you try:

```
$ conda tmpenv create
Traceback (most recent call last):
  File "/miniconda3/bin/conda-tmpenv", line 11, in <module>
    load_entry_point('conda-execute==0.7.0', 'console_scripts', 'conda-tmpenv')()
  File "/miniconda3/lib/python3.5/site-packages/conda_execute/tmpenv.py", line 249, in main
    exit(args.subcommand_func(args))
  File "/miniconda3/lib/python3.5/site-packages/conda_execute/tmpenv.py", line 184, in subcommand_create
    r = create_env(specs, force_recreation=args.force)
  File "/miniconda3/lib/python3.5/site-packages/conda_execute/tmpenv.py", line 96, in create_env
    with open(os.path.join(env_locn, 'conda-meta', 'execution.log'), 'a'):
FileNotFoundError: [Errno 2] No such file or directory: '/miniconda3/tmp_envs/e3b0c44298fc1c149afb/conda-meta/execution.log'
```

Relates to #28
